### PR TITLE
fix: Added missing permissions to the GitHub workflow (#13)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Task #13 

* Added missing permissions required for NuGet authentication step in the *GitHub* workflow