### PR TITLE
chore: Added internal `Error.AddDetail()` method to be used in *Maple.Result.Extensions.HttpClient* (#55)

### DIFF
--- a/src/Maple.Result/Error.cs
+++ b/src/Maple.Result/Error.cs
@@ -203,6 +203,12 @@ public record Error
         return this;
     }
 
+    internal Error AddDetail(ErrorDetail errorDetail)
+    {
+        _errorDetails.Add(errorDetail);
+        return this;
+    }
+
     #region factory methods
 
     /// <summary>

--- a/src/Maple.Result/Maple.Result.csproj
+++ b/src/Maple.Result/Maple.Result.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Maple.Result.Tests.Unit" />
+    <InternalsVisibleTo Include="Maple.Result.Extensions.HttpClient" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Task #55 

* Added internal `Error.AddDetail()` method to be used in *Maple.Result.Extensions.HttpClient*
